### PR TITLE
Add Brewfile.example and RECOMMENDED.md addressing issues #1-#11

### DIFF
--- a/Brewfile.example
+++ b/Brewfile.example
@@ -1,0 +1,77 @@
+# mac-onboarding recommended Brewfile
+#
+# Copy to ~/.Brewfile and customize:
+#   cp Brewfile.example ~/.Brewfile
+#   brew bundle install --file=~/.Brewfile
+#
+# mac-onboarding will export your ~/.Brewfile automatically.
+# Anything you add here will be captured on next `mac-onboarding export`.
+
+# ---------------------------------------------------------------------------
+# Taps
+# ---------------------------------------------------------------------------
+tap "homebrew/bundle"
+tap "homebrew/services"
+tap "umputun/apps"
+
+# ---------------------------------------------------------------------------
+# Core CLI tools
+# ---------------------------------------------------------------------------
+brew "git"
+brew "gh"               # GitHub CLI
+brew "curl"
+brew "wget"
+brew "jq"               # JSON processor
+brew "yq"               # YAML processor
+brew "tree"
+brew "htop"
+brew "tmux"
+brew "zsh"
+
+# ---------------------------------------------------------------------------
+# Shell prompt & git tooling
+# ---------------------------------------------------------------------------
+brew "starship"         # Fast cross-shell prompt — issue #4, #10
+brew "lazygit"          # Terminal UI for git — issue #11
+brew "ripgrep"          # Fast grep replacement
+brew "fzf"              # Fuzzy finder
+brew "bat"              # Better cat with syntax highlighting
+brew "eza"              # Modern ls replacement
+
+# ---------------------------------------------------------------------------
+# Umputun's tools
+# ---------------------------------------------------------------------------
+brew "umputun/apps/ralphex"   # Ralph Wiggum quote — issue #1
+brew "umputun/apps/revdiff"   # Reverse diff tool — issue #2
+
+# ---------------------------------------------------------------------------
+# Languages & runtimes (uncomment as needed)
+# ---------------------------------------------------------------------------
+# brew "node"
+# brew "go"
+# brew "rust"
+# brew "python@3.13"
+
+# ---------------------------------------------------------------------------
+# Casks — GUI apps
+# ---------------------------------------------------------------------------
+cask "kitty"            # Terminal
+cask "cursor"           # AI code editor
+cask "rectangle"        # Window manager
+cask "raycast"          # Spotlight replacement
+
+# Menu bar utilities
+cask "meetingbar"       # Calendar in menu bar — issue #9
+cask "vanilla"          # Hide menu bar icons — issue #8
+cask "swiftbar"         # Custom menu bar plugins
+cask "shottr"           # Screenshot tool
+cask "klack"            # Mechanical keyboard sounds
+cask "flux"             # Blue light filter
+
+# ---------------------------------------------------------------------------
+# Fonts — issue #5
+# ---------------------------------------------------------------------------
+cask "font-fira-code"
+cask "font-fira-code-nerd-font"
+cask "font-jetbrains-mono"
+cask "font-jetbrains-mono-nerd-font"

--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ mac-onboarding bridge pull --dry-run
 
 - [Website](https://mac.olegkoval.com/) - Project landing page
 - [Example config](onboard.yaml.example) - Complete module configuration template
+- [Recommended setup](RECOMMENDED.md) - Suggested tools, prompts, fonts, git defaults
+- [Brewfile.example](Brewfile.example) - Reference Brewfile (CLI tools + casks + fonts)
 - [GitHub Releases](https://github.com/oleg-koval/mac-onboarding/releases) - Published binaries
 - [Issues](https://github.com/oleg-koval/mac-onboarding/issues) - Bug reports and feature requests
 

--- a/RECOMMENDED.md
+++ b/RECOMMENDED.md
@@ -1,0 +1,76 @@
+# Recommended Setup
+
+A reference setup for new Macs. Everything here is captured automatically by `mac-onboarding export` once you've applied it locally.
+
+## 1. Brewfile
+
+Start from `Brewfile.example`:
+
+```bash
+cp Brewfile.example ~/.Brewfile
+brew bundle install --file=~/.Brewfile
+```
+
+`mac-onboarding export` reads `~/.Brewfile` by default. Add or remove tools as you like — the next export captures them.
+
+## 2. Shell — zsh + Starship
+
+Install [Starship](https://starship.rs) prompt:
+
+```bash
+brew install starship
+echo 'eval "$(starship init zsh)"' >> ~/.zshrc
+```
+
+For the [Catppuccin Powerline](https://starship.rs/presets/catppuccin-powerline) preset:
+
+```bash
+mkdir -p ~/.config && \
+  starship preset catppuccin-powerline -o ~/.config/starship.toml
+```
+
+Or, stock zsh with git branch in prompt — drop into `~/.zshrc`:
+
+```zsh
+# Load version control information
+autoload -Uz vcs_info
+precmd() { vcs_info }
+
+# Format the vcs_info_msg_0_ variable
+zstyle ':vcs_info:git:*' formats '(%b)'
+
+# Set up the prompt (with git branch name)
+setopt PROMPT_SUBST
+PROMPT='%F{magenta}==>%f %F{blue}${PWD/#$HOME/~}%f %F{cyan}${vcs_info_msg_0_}%f%F{green} ==> %f'
+```
+
+## 3. Git defaults
+
+```bash
+git config --global user.name "Your Name"
+git config --global user.email you@example.com
+git config --global push.autoSetupRemote true
+git config --global init.defaultBranch main
+
+# Verify
+git config --list
+```
+
+The `git` module captures `~/.gitconfig`, `~/.gitignore_global`, and `~/.config/git/` — credentials are redacted.
+
+## 4. Fonts
+
+Programming fonts ship via Homebrew casks (already in `Brewfile.example`):
+
+- **Fira Code** — popular, free, with ligatures
+- **JetBrains Mono** — JetBrains' free programming font
+- **Nerd Font variants** — include glyphs for Powerline / Starship icons
+
+Set them in your terminal of choice (Kitty, iTerm2, Cursor, etc.).
+
+## 5. Recommended order
+
+1. Run `mac-onboarding install ~/onboard.tar.gz` — Xcode CLT, Homebrew, modules
+2. Install the Brewfile bundle (auto-handled by `brew` module)
+3. Configure Starship, dotfiles, fonts (auto-handled by `shell` + `system` modules)
+4. Manually re-add SSH keys, 1Password, cloud creds (intentionally not exported)


### PR DESCRIPTION
Most issues requested specific tools (lazygit, starship, fira-code, meetingbar, vanilla, ralphex, revdiff, etc.) — all installable via brew. The brew module already exports ~/.Brewfile, so capturing them is automatic once they're added.

- Brewfile.example: reference Brewfile with all requested tools grouped by category (CLI, prompt, fonts, casks). Users copy to ~/.Brewfile and customize.
- RECOMMENDED.md: setup guide covering Starship config (issue #4, #10), zsh prompt addon (issue #6), git defaults (issue #7), fonts (issue #5).
- README links both files under Documentation.

Closes #1, #2, #3, #4, #5, #6, #7, #8, #9, #10, #11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `Brewfile.example` template for configuring Homebrew Bundle macOS setup
  * Added `RECOMMENDED.md` with a comprehensive Mac setup checklist and configuration workflow
  * Updated README with links to new setup guidance resources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->