### PR TITLE
feat: add --backup and --force flags to install command with conflict…

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -12,6 +12,8 @@ import (
 
 var installInput string
 var installFromStdin bool
+var installBackup bool
+var installForce bool
 
 var installCmd = &cobra.Command{
 	Use:   "install [ARCHIVE_PATH]",
@@ -65,6 +67,8 @@ Example:
 			Only:    only,
 			Verbose: verbose,
 			Input:   archivePath,
+			Backup:  installBackup,
+			Force:   installForce,
 		}
 
 		if dryRun {
@@ -78,5 +82,7 @@ Example:
 func init() {
 	installCmd.Flags().StringVarP(&installInput, "input", "i", "", "input archive path (required unless using --from-stdin)")
 	installCmd.Flags().BoolVar(&installFromStdin, "from-stdin", false, "read archive from stdin instead of file")
+	installCmd.Flags().BoolVar(&installBackup, "backup", false, "create timestamped backup of existing config before extracting")
+	installCmd.Flags().BoolVar(&installForce, "force", false, "overwrite existing config without prompting")
 	rootCmd.AddCommand(installCmd)
 }

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 type archiveEntry struct {
@@ -146,6 +147,60 @@ func ExtractDir(archivePath, prefix, dstDir string) error {
 		out.Close()
 	}
 	return nil
+}
+
+// BackupDir creates a timestamped snapshot of srcDir.
+// Returns the path to the backup directory (e.g., ~/.pi.backup-20260508-120000).
+func BackupDir(srcDir string) (string, error) {
+	if _, err := os.Stat(srcDir); err != nil {
+		return "", fmt.Errorf("stat %s: %w", srcDir, err)
+	}
+
+	now := time.Now().Format("20060102-150405")
+	backupPath := srcDir + ".backup-" + now
+
+	// Copy directory tree recursively
+	if err := filepath.Walk(srcDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(srcDir, path)
+		if err != nil {
+			return err
+		}
+		dst := filepath.Join(backupPath, rel)
+
+		if info.IsDir() {
+			return os.MkdirAll(dst, info.Mode())
+		}
+		// Skip symlinks, copy only regular files
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		// Create parent dir
+		if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+			return err
+		}
+		// Copy file
+		src, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer src.Close()
+		out, err := os.Create(dst)
+		if err != nil {
+			return err
+		}
+		defer out.Close()
+		if _, err := io.Copy(out, src); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		return "", fmt.Errorf("backup %s: %w", srcDir, err)
+	}
+
+	return backupPath, nil
 }
 
 // ListEntries returns all entry names in the archive.

--- a/internal/modules/ai_tools/ai_tools.go
+++ b/internal/modules/ai_tools/ai_tools.go
@@ -2,6 +2,7 @@
 package ai_tools
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -122,6 +123,34 @@ func (m *claudeModule) Install(cfg *config.Config, opts runner.Options, src stri
 	home, _ := os.UserHomeDir()
 	base := expandHome(configPath(cfg, "claude", "config_dir", filepath.Join(home, ".claude")))
 
+	if !opts.DryRun {
+		// Check for conflicts
+		if _, err := os.Stat(base); err == nil {
+			// Directory exists
+			if opts.Force {
+				// Silent overwrite
+			} else if opts.Backup {
+				// Backup before extracting
+				backupPath, err := archive.BackupDir(base)
+				if err != nil {
+					return fmt.Errorf("claude: backup failed: %w", err)
+				}
+				fmt.Printf("  claude: backed up %s → %s\n", base, backupPath)
+			} else {
+				// Prompt user
+				fmt.Printf("  claude: %s exists. Overwrite? (y/N) ", base)
+				scanner := bufio.NewScanner(os.Stdin)
+				if !scanner.Scan() {
+					return fmt.Errorf("claude: cancelled")
+				}
+				response := strings.ToLower(strings.TrimSpace(scanner.Text()))
+				if response != "y" && response != "yes" {
+					return fmt.Errorf("claude: cancelled")
+				}
+			}
+		}
+	}
+
 	entries, _ := archive.ListEntries(src)
 	for _, entry := range entries {
 		if !strings.HasPrefix(entry, "claude/") {
@@ -203,6 +232,34 @@ func (m *codexModule) Install(cfg *config.Config, opts runner.Options, src strin
 	home, _ := os.UserHomeDir()
 	base := expandHome(configPath(cfg, "codex", "config_dir", filepath.Join(home, ".codex")))
 
+	if !opts.DryRun {
+		// Check for conflicts
+		if _, err := os.Stat(base); err == nil {
+			// Directory exists
+			if opts.Force {
+				// Silent overwrite
+			} else if opts.Backup {
+				// Backup before extracting
+				backupPath, err := archive.BackupDir(base)
+				if err != nil {
+					return fmt.Errorf("codex: backup failed: %w", err)
+				}
+				fmt.Printf("  codex: backed up %s → %s\n", base, backupPath)
+			} else {
+				// Prompt user
+				fmt.Printf("  codex: %s exists. Overwrite? (y/N) ", base)
+				scanner := bufio.NewScanner(os.Stdin)
+				if !scanner.Scan() {
+					return fmt.Errorf("codex: cancelled")
+				}
+				response := strings.ToLower(strings.TrimSpace(scanner.Text()))
+				if response != "y" && response != "yes" {
+					return fmt.Errorf("codex: cancelled")
+				}
+			}
+		}
+	}
+
 	entries, _ := archive.ListEntries(src)
 	for _, entry := range entries {
 		if !strings.HasPrefix(entry, "codex/") {
@@ -264,6 +321,32 @@ func (m *piModule) Install(cfg *config.Config, opts runner.Options, src string) 
 	if opts.DryRun {
 		fmt.Printf("  dry-run: would restore archive:pi/ → %s\n", base)
 		return nil
+	}
+
+	// Check for conflicts
+	if _, err := os.Stat(base); err == nil {
+		// Directory exists
+		if opts.Force {
+			// Silent overwrite
+		} else if opts.Backup {
+			// Backup before extracting
+			backupPath, err := archive.BackupDir(base)
+			if err != nil {
+				return fmt.Errorf("pi: backup failed: %w", err)
+			}
+			fmt.Printf("  pi: backed up %s → %s\n", base, backupPath)
+		} else {
+			// Prompt user
+			fmt.Printf("  pi: %s exists. Overwrite? (y/N) ", base)
+			scanner := bufio.NewScanner(os.Stdin)
+			if !scanner.Scan() {
+				return fmt.Errorf("pi: cancelled")
+			}
+			response := strings.ToLower(strings.TrimSpace(scanner.Text()))
+			if response != "y" && response != "yes" {
+				return fmt.Errorf("pi: cancelled")
+			}
+		}
 	}
 
 	os.MkdirAll(base, 0755)

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -13,6 +13,8 @@ type Options struct {
 	Verbose bool
 	Output  string // export archive path
 	Input   string // install archive path
+	Backup  bool   // create timestamped backup before extracting
+	Force   bool   // overwrite without prompting
 }
 
 // Module is the interface every module must satisfy.


### PR DESCRIPTION
… resolution

- Add BackupDir() helper to create timestamped backups of existing config
- Update piModule, claudeModule, codexModule Install() with conflict handling:
  - --force: silent overwrite (for automation)
  - --backup: create backup before extracting
  - Default: prompt user if config exists
- New Options fields: Backup, Force bool
- Backup format: ~/.pi.backup-YYYYMMDD-HHMMSS

Addresses user question about handling existing config during install.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added `--backup` flag to create timestamped backups of existing configurations before installation
* Added `--force` flag to overwrite existing configurations without confirmation prompts
* Enhanced installation conflict handling with smart backup creation, overwrite options, and interactive prompts

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oleg-koval/mac-onboarding/pull/15)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->